### PR TITLE
Enable ffmpeg

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -61,7 +61,7 @@ Hyrax.config do |config|
   # config.persistent_hostpath = 'http://localhost/files/'
 
   # If you have ffmpeg installed and want to transcode audio and video set to true
-  # config.enable_ffmpeg = false
+  config.enable_ffmpeg = true
 
   # Hyrax uses NOIDs for files and collections instead of Fedora UUIDs
   # where NOID = 10-character string and UUID = 32-character string w/ hyphens


### PR DESCRIPTION
Flipping this setting will tell Hyrax to try running ffmpeg on audio and video files to generate derivatives.  I believe the docker container already has ffmpeg and I was able to ingest a video file and play it back.