### PR TITLE
Add xray-rails in development for easily identifying view partials

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development do
   # gem 'spring'
   # gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'bootsnap'
+  gem 'xray-rails'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -772,6 +772,8 @@ GEM
     xml-simple (1.1.5)
     xpath (3.0.0)
       nokogiri (~> 1.8)
+    xray-rails (0.3.1)
+      rails (>= 3.1.0)
 
 PLATFORMS
   ruby
@@ -806,6 +808,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webpacker (~> 3.0)
+  xray-rails
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
Pressing Cmd+Shift+x on a Mac and Ctrl+Shift+x shows which partials make up the current rendered page in a browser making it easier to debug issues in development.

https://github.com/brentd/xray-rails