### PR TITLE
Generate IIIF Presentation 3.0 manifests for AV content

### DIFF
--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -11,6 +11,9 @@ RSpec/VerifiedDoubles:
   Exclude:
     - 'spec/presenters/hyrax/generic_work_presenter_spec.rb'
 
+RSpec/NamedSubject:
+  Enabled: false
+
 # Copied from Hyrax
 # # By default RSpec/MessageSpies has the following:
 # #   Prefer have_received for setting message expectations. Setup form as a spy using allow or instance_spy.

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ group :development, :test do
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
   gem 'factory_bot_rails'
+  gem 'rspec-its'
 end
 
 gem 'webpacker', '~> 3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'hyrax', '2.1.0.beta1'
+gem 'hyrax', '2.1.0.beta2'
 group :development, :test do
   gem 'bixby'
   gem 'solr_wrapper', '>= 0.3'
@@ -87,3 +87,4 @@ end
 gem 'config'
 
 gem 'riiif', '~> 1.1'
+gem 'iiif_manifest', github: 'samvera-labs/iiif_manifest', branch: 'prezi3'

--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,4 @@ gem 'config'
 
 gem 'riiif', '~> 1.1'
 gem 'iiif_manifest', github: 'samvera-labs/iiif_manifest', branch: 'prezi3'
+gem 'hydra-works', github: 'avalonmediasystem/hydra-works', branch: 'av_characterization'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/samvera-labs/iiif_manifest.git
-  revision: 6c75b263d3d45da2978fc789886ccddeccc27a3e
+  revision: 139b553dd5563890dc2ba038b48445556fea6559
   branch: prezi3
   specs:
     iiif_manifest (0.4.0)
@@ -373,7 +373,7 @@ GEM
       signet
       simple_form (~> 3.2, <= 3.5.0)
       tinymce-rails (~> 4.1)
-    i18n (0.9.3)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     inflecto (0.0.2)
@@ -772,7 +772,7 @@ GEM
       actionpack (>= 3.1)
       jquery-rails
       railties (>= 3.1)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.1.0)
     uglifier (4.1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/samvera-labs/iiif_manifest.git
+  revision: 6c75b263d3d45da2978fc789886ccddeccc27a3e
+  branch: prezi3
+  specs:
+    iiif_manifest (0.4.0)
+      activesupport (>= 4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -66,19 +74,19 @@ GEM
       rails (>= 4.2, < 6)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.1.0)
+    autoprefixer-rails (8.2.0)
       execjs
     awesome_nested_set (3.1.4)
       activerecord (>= 4.0.0, < 5.3)
-    aws-partitions (1.69.0)
-    aws-sdk-core (3.17.0)
+    aws-partitions (1.80.0)
+    aws-sdk-core (3.19.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
     aws-sdk-kms (1.5.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.8.2)
+    aws-sdk-s3 (1.9.0)
       aws-sdk-core (~> 3)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
@@ -245,19 +253,19 @@ GEM
       activesupport (>= 4.0)
     flot-rails (0.0.7)
       jquery-rails
-    font-awesome-rails (4.7.0.3)
-      railties (>= 3.2, < 5.2)
+    font-awesome-rails (4.7.0.4)
+      railties (>= 3.2, < 6.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    google-api-client (0.19.8)
+    google-api-client (0.20.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
       httpclient (>= 2.8.1, < 3.0)
       mime-types (~> 3.0)
       representable (~> 3.0)
       retriable (>= 2.0, < 4.0)
-    google_drive (2.1.9)
-      google-api-client (>= 0.11.0, < 0.20.0)
+    google_drive (2.1.3)
+      google-api-client (>= 0.11.0, < 1.0.0)
       googleauth (>= 0.5.0, < 1.0.0)
       nokogiri (>= 1.5.3, < 2.0.0)
     googleauth (0.6.2)
@@ -276,7 +284,7 @@ GEM
     hiredis (0.6.1)
     htmlentities (4.3.4)
     http_logger (0.5.1)
-    httparty (0.16.0)
+    httparty (0.16.2)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     hydra-access-controls (10.5.0)
@@ -318,7 +326,7 @@ GEM
       hydra-file_characterization (~> 0.3, >= 0.3.3)
       hydra-pcdm (>= 0.9)
       om (~> 3.1)
-    hyrax (2.1.0.beta1)
+    hyrax (2.1.0.beta2)
       active-fedora (~> 11.5, >= 11.5.2)
       almond-rails (~> 0.1)
       awesome_nested_set (~> 3.1)
@@ -338,7 +346,7 @@ GEM
       hydra-editor (~> 3.3)
       hydra-head (>= 10.5.0)
       hydra-works (~> 0.16)
-      iiif_manifest (~> 0.3.0)
+      iiif_manifest (>= 0.3, < 0.5)
       jquery-datatables-rails (~> 3.4)
       jquery-ui-rails (~> 6.0)
       json-schema
@@ -363,23 +371,16 @@ GEM
       samvera-nesting_indexer (~> 1.0, >= 1.0.1)
       select2-rails (~> 3.5)
       signet
-      simple_form (= 3.5.0)
+      simple_form (~> 3.2, <= 3.5.0)
       tinymce-rails (~> 4.1)
     i18n (0.9.3)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    iiif-presentation (0.2.0)
-      activesupport (>= 3.2.18)
-      faraday (>= 0.9)
-      json
-    iiif_manifest (0.3.0)
-      activesupport (>= 4)
-      iiif-presentation (~> 0.2.0)
     inflecto (0.0.2)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
-    jmespath (1.3.1)
+    jmespath (1.4.0)
     jquery-datatables-rails (3.4.0)
       actionpack (>= 3.1)
       jquery-rails
@@ -422,7 +423,7 @@ GEM
       rdf-xsd (>= 2.2, < 4.0)
       sparql (>= 2.2, < 4.0)
       sxp (~> 1.0)
-    ldp (0.7.0)
+    ldp (0.7.2)
       deprecation
       faraday
       http_logger
@@ -717,7 +718,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    slop (4.6.1)
+    slop (4.6.2)
     solr_wrapper (1.2.0)
       faraday
       retriable
@@ -762,7 +763,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
-    tinymce-rails (4.7.9)
+    tinymce-rails (4.7.10)
       railties (>= 3.1.1)
     turbolinks (5.1.0)
       turbolinks-source (~> 5.1)
@@ -814,7 +815,8 @@ DEPENDENCIES
   devise-guests (~> 0.6)
   factory_bot_rails
   fcrepo_wrapper
-  hyrax (= 2.1.0.beta1)
+  hyrax (= 2.1.0.beta2)
+  iiif_manifest!
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -656,6 +656,9 @@ GEM
     rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
@@ -832,6 +835,7 @@ DEPENDENCIES
   rails (~> 5.1.4)
   riiif (~> 1.1)
   rsolr (>= 1.0)
+  rspec-its
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,15 @@
 GIT
+  remote: https://github.com/avalonmediasystem/hydra-works.git
+  revision: d056245f340beaf9bf7ad42a276de460b789e475
+  branch: av_characterization
+  specs:
+    hydra-works (0.17.0)
+      hydra-derivatives (~> 3.0)
+      hydra-file_characterization (~> 0.3, >= 0.3.3)
+      hydra-pcdm (>= 0.9)
+      om (~> 3.1)
+
+GIT
   remote: https://github.com/samvera-labs/iiif_manifest.git
   revision: 139b553dd5563890dc2ba038b48445556fea6559
   branch: prezi3
@@ -321,11 +332,6 @@ GEM
     hydra-pcdm (0.11.0)
       active-fedora (>= 10, < 13)
       mime-types (>= 1)
-    hydra-works (0.17.0)
-      hydra-derivatives (~> 3.0)
-      hydra-file_characterization (~> 0.3, >= 0.3.3)
-      hydra-pcdm (>= 0.9)
-      om (~> 3.1)
     hyrax (2.1.0.beta2)
       active-fedora (~> 11.5, >= 11.5.2)
       almond-rails (~> 0.1)
@@ -815,6 +821,7 @@ DEPENDENCIES
   devise-guests (~> 0.6)
   factory_bot_rails
   fcrepo_wrapper
+  hydra-works!
   hyrax (= 2.1.0.beta2)
   iiif_manifest!
   jbuilder (~> 2.5)

--- a/app/controllers/hyrax/generic_works_controller.rb
+++ b/app/controllers/hyrax/generic_works_controller.rb
@@ -10,5 +10,16 @@ module Hyrax
 
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::GenericWorkPresenter
+
+    private
+
+    def manifest_builder
+      # TODO Switch to all V3 Manifests in the future or make based upon request headers
+      if presenter.representative_presenter.image?
+        ::IIIFManifest::ManifestFactory.new(presenter)
+      else
+        ::IIIFManifest::V3::ManifestFactory.new(presenter)
+      end
+    end
   end
 end

--- a/app/controllers/hyrax/generic_works_controller.rb
+++ b/app/controllers/hyrax/generic_works_controller.rb
@@ -13,13 +13,13 @@ module Hyrax
 
     private
 
-    def manifest_builder
-      # TODO Switch to all V3 Manifests in the future or make based upon request headers
-      if presenter.representative_presenter.image?
-        ::IIIFManifest::ManifestFactory.new(presenter)
-      else
-        ::IIIFManifest::V3::ManifestFactory.new(presenter)
+      def manifest_builder
+        # TODO: Switch to all V3 Manifests in the future or make based upon request headers
+        if presenter.representative_presenter.image?
+          ::IIIFManifest::ManifestFactory.new(presenter)
+        else
+          ::IIIFManifest::V3::ManifestFactory.new(presenter)
+        end
       end
-    end
   end
 end

--- a/app/presenters/hyrax/av_file_set_presenter.rb
+++ b/app/presenters/hyrax/av_file_set_presenter.rb
@@ -1,0 +1,5 @@
+module Hyrax
+  class AVFileSetPresenter < Hyrax::FileSetPresenter
+    include DisplaysContent
+  end
+end

--- a/app/presenters/hyrax/displays_content.rb
+++ b/app/presenters/hyrax/displays_content.rb
@@ -64,10 +64,10 @@ module Hyrax
     def audio_content(original_file)
       [IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'ogg'),
                                        duration: original_file.duration.try(:first),
-                                       type: 'Audio'),
+                                       type: 'Sound'),
        IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'mp3'),
                                         duration: original_file.duration.try(:first),
-                                        type: 'Audio')]
+                                        type: 'Sound')]
     end
 
     def download_path(file_set, extension)

--- a/app/presenters/hyrax/displays_content.rb
+++ b/app/presenters/hyrax/displays_content.rb
@@ -12,9 +12,9 @@ module Hyrax
     def display_content
       return nil unless display_content_allowed?
 
-      image_content if solr_document.image?
-      video_content if solr_document.video?
-      audio_content if solr_document.audio?
+      return image_content if solr_document.image?
+      return video_content if solr_document.video?
+      return audio_content if solr_document.audio?
     end
 
     private

--- a/app/presenters/hyrax/displays_content.rb
+++ b/app/presenters/hyrax/displays_content.rb
@@ -1,0 +1,77 @@
+require 'iiif_manifest'
+
+module Hyrax
+  # This gets mixed into FileSetPresenter in order to create
+  # a canvas on a IIIF manifest
+  module DisplaysContent
+    extend ActiveSupport::Concern
+
+    # Creates a display content only where FileSet is an image or video.
+    #
+    # @return [IIIFManifest::V3::DisplayContent] the display content required by the manifest builder.
+    def display_content
+      return nil unless ::FileSet.exists?(id) && content_supported? && current_ability.can?(:read, id)
+      # @todo this is slow, find a better way (perhaps index iiif url):
+      # original_file = ::FileSet.find(id).original_file
+      # file_set = ::FileSet.find(id)
+      file_set = solr_document
+
+      if solr_document.image?
+        image_content(file_set)
+      elsif solr_document.video?
+        video_content(file_set)
+      elsif solr_document.audio?
+        audio_content(file_set)
+      else
+        nil
+      end
+    end
+
+    private
+
+    def content_supported?
+      solr_document.video? || solr_document.audio? #|| solr_document.image?
+    end
+
+    def image_content(original_file)
+      url = Hyrax.config.iiif_image_url_builder.call(
+        original_file.id,
+        request.base_url,
+        Hyrax.config.iiif_image_size_default
+      )
+      # @see https://github.com/samvera-labs/iiif_manifest
+      IIIFManifest::V3::DisplayContent.new(url,
+                                     width: 640,
+                                     height: 480,
+                                     type: 'Image',
+                                     iiif_endpoint: iiif_endpoint(original_file.id))
+    end
+
+    def video_content(original_file)
+      # @see https://github.com/samvera-labs/iiif_manifest
+      [IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'mp4'),
+                                       width: original_file.width.try(:first),
+                                       height: original_file.height.try(:first),
+                                       duration: original_file.duration.try(:first),
+                                       type: 'Video'),
+       IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'webm'),
+                                        width: original_file.width.try(:first),
+                                        height: original_file.height.try(:first),
+                                        duration: original_file.duration.try(:first),
+                                        type: 'Video')]
+    end
+
+    def audio_content(original_file)
+      [IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'ogg'),
+                                       duration: original_file.duration.try(:first),
+                                       type: 'Audio'),
+       IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'mp3'),
+                                        duration: original_file.duration.try(:first),
+                                        type: 'Audio')]
+    end
+
+    def download_path(file_set, extension)
+      Hyrax::Engine.routes.url_helpers.download_url(file_set, file: extension, host: request.base_url)
+    end
+  end
+end

--- a/app/presenters/hyrax/displays_content.rb
+++ b/app/presenters/hyrax/displays_content.rb
@@ -50,23 +50,23 @@ module Hyrax
     def video_content(original_file)
       # @see https://github.com/samvera-labs/iiif_manifest
       [IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'mp4'),
-                                       width: original_file.width.try(:first),
-                                       height: original_file.height.try(:first),
-                                       duration: original_file.duration.try(:first),
+                                       width: Array(original_file.width).first.try(:to_i),
+                                       height: Array(original_file.height).first.try(:to_i),
+                                       duration: Array(original_file.duration).first.try(:to_i),
                                        type: 'Video'),
        IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'webm'),
-                                        width: original_file.width.try(:first),
-                                        height: original_file.height.try(:first),
-                                        duration: original_file.duration.try(:first),
+                                        width: Array(original_file.width).first.try(:to_i),
+                                        height: Array(original_file.height).first.try(:to_i),
+                                        duration: Array(original_file.duration).first.try(:to_i),
                                         type: 'Video')]
     end
 
     def audio_content(original_file)
       [IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'ogg'),
-                                       duration: original_file.duration.try(:first),
+                                       duration: Array(original_file.duration).first.try(:to_i),
                                        type: 'Sound'),
        IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'mp3'),
-                                        duration: original_file.duration.try(:first),
+                                        duration: Array(original_file.duration).first.try(:to_i),
                                         type: 'Sound')]
     end
 

--- a/app/presenters/hyrax/displays_content.rb
+++ b/app/presenters/hyrax/displays_content.rb
@@ -15,74 +15,72 @@ module Hyrax
 
       if solr_document.image?
         image_content_v2(file_set)
-        # TODO look at the request and target 2 or 3?
+        # TODO: look at the request and target 2 or 3?
       elsif solr_document.video?
         video_content(file_set)
       elsif solr_document.audio?
         audio_content(file_set)
-      else
-        nil
       end
     end
 
     private
 
-    def content_supported?
-      solr_document.video? || solr_document.audio? || solr_document.image?
-    end
+      def content_supported?
+        solr_document.video? || solr_document.audio? || solr_document.image?
+      end
 
-    def image_content_v3(original_file)
-      url = Hyrax.config.iiif_image_url_builder.call(
-        original_file.id,
-        request.base_url,
-        Hyrax.config.iiif_image_size_default
-      )
-      # @see https://github.com/samvera-labs/iiif_manifest
-      IIIFManifest::V3::DisplayContent.new(url,
-                                     width: 640,
-                                     height: 480,
-                                     type: 'Image',
-                                     iiif_endpoint: iiif_endpoint(original_file.id))
-    end
+      def image_content_v3(original_file)
+        url = Hyrax.config.iiif_image_url_builder.call(
+          original_file.id,
+          request.base_url,
+          Hyrax.config.iiif_image_size_default
+        )
+        # @see https://github.com/samvera-labs/iiif_manifest
+        IIIFManifest::V3::DisplayContent.new(url,
+                                             width: 640,
+                                             height: 480,
+                                             type: 'Image',
+                                             iiif_endpoint: iiif_endpoint(original_file.id))
+      end
 
-    def image_content_v2(original_file)
-      url = Hyrax.config.iiif_image_url_builder.call(
-        original_file.id,
-        request.base_url,
-        Hyrax.config.iiif_image_size_default
-      )
-      # @see https://github.com/samvera-labs/iiif_manifest
-      IIIFManifest::DisplayImage.new(url,
-                                     width: 640,
-                                     height: 480,
-                                     iiif_endpoint: iiif_endpoint(original_file.id))
-    end
+      def image_content_v2(original_file)
+        url = Hyrax.config.iiif_image_url_builder.call(
+          original_file.id,
+          request.base_url,
+          Hyrax.config.iiif_image_size_default
+        )
+        # @see https://github.com/samvera-labs/iiif_manifest
+        IIIFManifest::DisplayImage.new(url,
+                                       width: 640,
+                                       height: 480,
+                                       iiif_endpoint: iiif_endpoint(original_file.id))
+      end
 
-    def video_content(original_file)
-      # @see https://github.com/samvera-labs/iiif_manifest
-      [IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'mp4'),
-                                       width: Array(original_file.width).first.try(:to_i),
-                                       height: Array(original_file.height).first.try(:to_i),
-                                       duration: Array(original_file.duration).first.try(:to_i),
-                                       type: 'Video'),
-       IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'webm'),
-                                        width: Array(original_file.width).first.try(:to_i),
-                                        height: Array(original_file.height).first.try(:to_i),
-                                        duration: Array(original_file.duration).first.try(:to_i),
-                                        type: 'Video')]
-    end
+      def video_content(original_file)
+        # @see https://github.com/samvera-labs/iiif_manifest
+        [IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'mp4'),
+                                              width: Array(original_file.width).first.try(:to_i),
+                                              height: Array(original_file.height).first.try(:to_i),
+                                              duration: Array(original_file.duration).first.try(:to_i),
+                                              type: 'Video'),
+         IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'webm'),
+                                              width: Array(original_file.width).first.try(:to_i),
+                                              height: Array(original_file.height).first.try(:to_i),
+                                              duration: Array(original_file.duration).first.try(:to_i),
+                                              type: 'Video')]
+      end
 
-    def audio_content(original_file)
-      [IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'ogg'),
-                                       duration: Array(original_file.duration).first.try(:to_i),
-                                       type: 'Sound'),
-       IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'mp3'),
-                                        duration: Array(original_file.duration).first.try(:to_i),
-                                        type: 'Sound')]
-    end
+      def audio_content(original_file)
+        [IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'ogg'),
+                                              duration: Array(original_file.duration).first.try(:to_i),
+                                              type: 'Sound'),
+         IIIFManifest::V3::DisplayContent.new(download_path(original_file, 'mp3'),
+                                              duration: Array(original_file.duration).first.try(:to_i),
+                                              type: 'Sound')]
+      end
 
-    def download_path(file_set, extension)
-      Hyrax::Engine.routes.url_helpers.download_url(file_set, file: extension, host: request.base_url)
-    end
+      def download_path(file_set, extension)
+        Hyrax::Engine.routes.url_helpers.download_url(file_set, file: extension, host: request.base_url)
+      end
   end
 end

--- a/app/presenters/hyrax/generic_work_presenter.rb
+++ b/app/presenters/hyrax/generic_work_presenter.rb
@@ -2,6 +2,9 @@
 #  `rails generate hyrax:work GenericWork`
 module Hyrax
   class GenericWorkPresenter < Hyrax::WorkShowPresenter
+
+    Hyrax::MemberPresenterFactory.file_presenter_class = Hyrax::AVFileSetPresenter
+
     # @return [Boolean] render a IIIF viewer
     def iiif_viewer?
       representative_id.present? &&

--- a/app/presenters/hyrax/generic_work_presenter.rb
+++ b/app/presenters/hyrax/generic_work_presenter.rb
@@ -2,7 +2,6 @@
 #  `rails generate hyrax:work GenericWork`
 module Hyrax
   class GenericWorkPresenter < Hyrax::WorkShowPresenter
-
     Hyrax::MemberPresenterFactory.file_presenter_class = Hyrax::AVFileSetPresenter
 
     # @return [Boolean] render a IIIF viewer

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,6 +1,6 @@
 development:
   url: <%= ENV["SOLR_URL"] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
 test:
-  url: <%= ENV["SOLR_URL"] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-test" %>
+  url: <%= ENV["SOLR_URL"] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8985)}/solr/hydra-test" %>
 production:
   url: <%= ENV["SOLR_URL"] || "http://your.production.server:8080/bl_solr/core0" %>

--- a/spec/presenters/hyrax/av_file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/av_file_set_presenter_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Hyrax::AVFileSetPresenter do
   let(:solr_document) { SolrDocument.new(id: '12345') }
-  let(:request) { double(base_url: 'http://test.host') }
-  let(:ability) { double "Ability" }
+  let(:request) { instance_double("Request", base_url: 'http://test.host') }
+  let(:ability) { instance_double("Ability") }
   let(:presenter) { described_class.new(solr_document, ability, request) }
   let(:read_permission) { true }
   let(:id) { solr_document.id }
@@ -27,8 +27,6 @@ RSpec.describe Hyrax::AVFileSetPresenter do
 
     context 'with a file' do
       context "when the file is not a known file" do
-        let(:file_path) { File.open(fixture_path + '/hyrax_generic_stub.txt') }
-
         it { is_expected.to be_nil }
       end
 
@@ -59,6 +57,7 @@ RSpec.describe Hyrax::AVFileSetPresenter do
           allow(solr_document).to receive(:video?).and_return(true)
         end
 
+        # rubocop:disable RSpec/ExampleLength
         it 'creates an array of content objects' do
           expect(subject).to all(be_instance_of IIIFManifest::V3::DisplayContent)
           expect(subject.length).to eq 2
@@ -68,11 +67,10 @@ RSpec.describe Hyrax::AVFileSetPresenter do
           expect(subject.map(&:duration)).to all(eq 1000)
           expect(subject.map(&:url)).to match_array([mp4_url, webm_url])
         end
+        # rubocop:enable RSpec/ExampleLength
       end
 
       context "when the file is an image" do
-        let(:file_path) { File.open(fixture_path + '/world.png') }
-
         before do
           allow(solr_document).to receive(:image?).and_return(true)
         end

--- a/spec/presenters/hyrax/av_file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/av_file_set_presenter_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::AVFileSetPresenter do
+  let(:solr_document) { SolrDocument.new(id: '12345') }
+  let(:request) { double(base_url: 'http://test.host') }
+  let(:ability) { double "Ability" }
+  let(:presenter) { described_class.new(solr_document, ability, request) }
+  let(:read_permission) { true }
+  let(:id) { solr_document.id }
+
+  before do
+    allow(ability).to receive(:can?).with(:read, solr_document.id).and_return(read_permission)
+  end
+
+  describe '#display_content' do
+    it 'responds to #display_content' do
+      expect(presenter.respond_to?(:display_content)).to be true
+    end
+
+    subject { presenter.display_content }
+
+    context 'without a file' do
+      let(:id) { 'bogus' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with a file' do
+      context "when the file is not a known file" do
+        let(:file_path) { File.open(fixture_path + '/hyrax_generic_stub.txt') }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "when the file is a sound recording" do
+        let(:solr_document) { SolrDocument.new(id: '12345', duration_tesim: 1000) }
+        let(:mp3_url) { "http://test.host/downloads/#{solr_document.id}?file=mp3" }
+        let(:ogg_url) { "http://test.host/downloads/#{solr_document.id}?file=ogg" }
+
+        before do
+          allow(solr_document).to receive(:audio?).and_return(true)
+        end
+
+        it 'creates an array of content objects' do
+          expect(subject).to all(be_instance_of IIIFManifest::V3::DisplayContent)
+          expect(subject.length).to eq 2
+          expect(subject.map(&:type)).to all(eq 'Sound')
+          expect(subject.map(&:duration)).to all(eq 1000)
+          expect(subject.map(&:url)).to match_array([mp3_url, ogg_url])
+        end
+      end
+
+      context "when the file is a video" do
+        let(:solr_document) { SolrDocument.new(id: '12345', width_is: 640, height_is: 480, duration_tesim: 1000) }
+        let(:mp4_url) { "http://test.host/downloads/#{id}?file=mp4" }
+        let(:webm_url) { "http://test.host/downloads/#{id}?file=webm" }
+
+        before do
+          allow(solr_document).to receive(:video?).and_return(true)
+        end
+
+        it 'creates an array of content objects' do
+          expect(subject).to all(be_instance_of IIIFManifest::V3::DisplayContent)
+          expect(subject.length).to eq 2
+          expect(subject.map(&:type)).to all(eq 'Video')
+          expect(subject.map(&:width)).to all(eq 640)
+          expect(subject.map(&:height)).to all(eq 480)
+          expect(subject.map(&:duration)).to all(eq 1000)
+          expect(subject.map(&:url)).to match_array([mp4_url, webm_url])
+        end
+      end
+
+      context "when the file is an image" do
+        let(:file_path) { File.open(fixture_path + '/world.png') }
+
+        before do
+          allow(solr_document).to receive(:image?).and_return(true)
+        end
+
+        it 'creates a content object' do
+          expect(subject).to be_instance_of IIIFManifest::DisplayImage
+          expect(subject.url).to eq "http://test.host/images/#{id}/full/600,/0/default.jpg"
+        end
+
+        context 'with custom image size default' do
+          let(:custom_image_size) { '666,' }
+
+          around do |example|
+            default_image_size = Hyrax.config.iiif_image_size_default
+            Hyrax.config.iiif_image_size_default = custom_image_size
+            example.run
+            Hyrax.config.iiif_image_size_default = default_image_size
+          end
+
+          it 'creates a content object' do
+            expect(subject).to be_instance_of IIIFManifest::DisplayImage
+            expect(subject.url).to eq "http://test.host/images/#{id}/full/#{custom_image_size}/0/default.jpg"
+          end
+        end
+
+        context 'with custom image url builder' do
+          let(:custom_builder) do
+            ->(file_id, base_url, _size) { "#{base_url}/downloads/#{file_id.split('/').first}" }
+          end
+
+          around do |example|
+            default_builder = Hyrax.config.iiif_image_url_builder
+            Hyrax.config.iiif_image_url_builder = custom_builder
+            example.run
+            Hyrax.config.iiif_image_url_builder = default_builder
+          end
+
+          it 'creates a content object' do
+            expect(subject).to be_instance_of IIIFManifest::DisplayImage
+            expect(subject.url).to eq "http://test.host/downloads/#{id.split('/').first}"
+          end
+        end
+
+        context "when the user doesn't have permission to view the image" do
+          let(:read_permission) { false }
+
+          it { is_expected.to be_nil }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR uses a branch of `iiif_manifest` and `hydra-works` to generate IIIF Presentation 3.0 manifests for video and audio representative files.  This PR does not generate Presentation 3.0 manifests for image content because the version of UV bundled with hyrax can't handle them.

### TODO
- [x] Add tests
- [x] Fix style issues
- [x] Add documentation
- ~~Make PRs to `iiif_manifest` and `hydra-works` and switch to master branches or releases of the gems~~ _(will be handled in separate issues)_