### PR TITLE
Updated README for alternative Mac OSX non-Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Avalon is served by Puma in development mode so any changes will be picked up au
 Rails debugging with Pry can be accessed by attaching to the docker container: ```docker attach avalon_container_name```. Now, when you reach a binding.pry breakpoint in rails, you can step through the breakpoint in that newly attached session.
 
 ## Note for Mac users
+*Note: Currently this approach is not stable and still in development mode.  It's recommended you start the application outside of Docker, following the instructions in the following section.*
+
 Bind-mounted volumes are notoriously slow on Docker for Mac, it is recommended that you use [docker-sync](https://github.com/EugenMayer/docker-sync/) to speed up development:
 * ``gem install docker-sync``
 * ``docker-sync-stack start`` (this replaces ``docker-compose up``)
@@ -26,4 +28,46 @@ bundle install
 yarn install
 rails db:migrate
 rails hydra:server
+```
+
+## (Alternative instructions) Getting Started Without Docker for Mac OSX
+```
+bundle install
+yarn install
+bundle exec rails db:migrate
+```
+
+If you don't have Redis server running automatically on your machine at start up, start it manually:
+```
+redis-server`
+```
+
+Start Solr and Fedora manually:
+```
+solr_wrapper
+fcrepo_wrapper
+```
+
+Configure an admin set, so that you can do things like add a new Work:
+```
+rails hyrax:default_admin_set:create
+```
+
+Configure fits; see instructions here, specifically list item #4:
+https://github.com/samvera/hyrax/wiki/Configuring-an-OS-X-Samvera-Dev-Environment#configuring-hyrax
+
+Start the application:
+```
+bundle exec rails s
+```
+
+By default it will run on port `:3000`.  If you have a port conflict in your local dev / bash environment, you can specify a port directly, ie:
+`bundle exec rails s -p 3333`
+
+Visit `http://localhost:3000/` and make sure the application loads.
+
+Sign up a new user:
+```
+username: archivist1@example.com
+password: archivist1
 ```


### PR DESCRIPTION
Fixes updates necessary for README ; refs #27 
