### PR TITLE
Works with audio or video representative media default to IIIF presen…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ yarn-error.log*
 .tern-project
 
 /gems
+/vendor/gems
+/public/assets

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   # gem 'spring'
   # gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'bootsnap'
   gem 'xray-rails'
   gem 'bumbler'
 end
@@ -74,6 +73,7 @@ gem 'devise-guests', '~> 0.6'
 gem 'jquery-rails'
 gem 'rsolr', '>= 1.0'
 group :development, :test do
+  gem 'bootsnap'
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
   gem 'factory_bot_rails'

--- a/app/controllers/hyrax/generic_works_controller.rb
+++ b/app/controllers/hyrax/generic_works_controller.rb
@@ -7,8 +7,8 @@ module Hyrax
     include Hyrax::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
 
-    IIIF_DEFAULT_VERSION = 2
-    IIIF_DEFAULT_MANIFEST_MIME = "application/json;profile=http://iiif.io/api/presentation/#{IIIF_DEFAULT_VERSION}/context.json".freeze
+    IIIF_PRESENTATION_2_MIME = "application/json;profile=http://iiif.io/api/presentation/2/context.json".freeze
+    IIIF_PRESENTATION_3_MIME = "application/json;profile=http://iiif.io/api/presentation/3/context.json".freeze
 
     self.curation_concern_type = ::GenericWork
 
@@ -22,27 +22,18 @@ module Hyrax
 
     private
 
-      # @return the highest IIIF version (as an integer) specified in the Accept request header, or the default version if none specified
-      def iiif_version
-        version = 0 # assume all valid versions will be at least greater than 0
-        accept = request.headers['Accept']
-        # check for multiple profiles for highest IIIF version. Note: only digits are allowed in the version number
-        regexp = Regexp.new(Regexp.escape(IIIF_DEFAULT_MANIFEST_MIME[/profile.*$/]).gsub("/#{IIIF_DEFAULT_VERSION}/", "/(\\d+)/"))
-        accept.scan(regexp).each do |matched|
-          v = matched[0].to_i
-          version = v > version ? v : version
-        end
-        version.zero? ? IIIF_DEFAULT_VERSION : version
-      end
-
       # @return true if the request is for IIIF version 3; false otherwise
       def iiif_version_3?
-        iiif_version == 3
+        presenter.iiif_version == 3
+      end
+
+      def iiif_mime
+        iiif_version_3? ? IIIF_PRESENTATION_3_MIME : IIIF_PRESENTATION_2_MIME
       end
 
       # Adds Content-Type response header based on request's Accept version
       def add_iiif_header
-        headers['Content-Type'] = IIIF_DEFAULT_MANIFEST_MIME.gsub("/#{IIIF_DEFAULT_VERSION}/", "/#{iiif_version}/")
+        headers['Content-Type'] = iiif_mime
       end
 
       def manifest_builder

--- a/app/presenters/hyrax/displays_content.rb
+++ b/app/presenters/hyrax/displays_content.rb
@@ -34,8 +34,8 @@ module Hyrax
           Hyrax.config.iiif_image_size_default
         )
 
-        # TODO: look at the request and target prezi 2 or 3 for images
-        image_content_v2(url)
+        # Look at the request and target prezi 2 or 3 for images
+        parent.iiif_version == 3 ? image_content_v3(url) : image_content_v2(url)
       end
 
       def image_content_v3(url)

--- a/app/presenters/hyrax/generic_work_presenter.rb
+++ b/app/presenters/hyrax/generic_work_presenter.rb
@@ -4,6 +4,9 @@ module Hyrax
   class GenericWorkPresenter < Hyrax::WorkShowPresenter
     Hyrax::MemberPresenterFactory.file_presenter_class = Hyrax::AVFileSetPresenter
 
+    IIIF_DEFAULT_VERSION = 2
+    IIIF_DEFAULT_MANIFEST_MIME = "application/json;profile=http://iiif.io/api/presentation/#{IIIF_DEFAULT_VERSION}/context.json".freeze
+
     # @return [Boolean] render a IIIF viewer
     def iiif_viewer?
       representative_id.present? &&
@@ -23,5 +26,31 @@ module Hyrax
         :universal_viewer
       end
     end
+
+    # @return the highest IIIF version (as an integer) specified in the Accept request header, or the default version if none specified
+    def iiif_version
+      accept = request.headers['Accept']
+      return parse_accept(accept) if accept.present?
+      if representative_presenter.present? &&
+         (representative_presenter.video? ||
+          representative_presenter.audio?)
+        3
+      else
+        IIIF_DEFAULT_VERSION
+      end
+    end
+
+    private
+
+      def parse_accept(accept)
+        version = 0 # assume all valid versions will be at least greater than 0
+        # check for multiple profiles for highest IIIF version. Note: only digits are allowed in the version number
+        regexp = Regexp.new(Regexp.escape(IIIF_DEFAULT_MANIFEST_MIME[/profile.*$/]).gsub("/#{IIIF_DEFAULT_VERSION}/", "/(\\d+)/"))
+        accept.scan(regexp).each do |matched|
+          v = matched[0].to_i
+          version = v > version ? v : version
+        end
+        version.zero? ? IIIF_DEFAULT_VERSION : version
+      end
   end
 end

--- a/spec/presenters/hyrax/av_file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/av_file_set_presenter_spec.rb
@@ -7,9 +7,11 @@ RSpec.describe Hyrax::AVFileSetPresenter do
   let(:presenter) { described_class.new(solr_document, ability, request) }
   let(:read_permission) { true }
   let(:id) { solr_document.id }
+  let(:parent_presenter) { instance_double("Hyrax::GenericWorkPresenter", iiif_version: 2) }
 
   before do
     allow(ability).to receive(:can?).with(:read, solr_document.id).and_return(read_permission)
+    allow(presenter).to receive(:parent).and_return(parent_presenter)
   end
 
   describe '#display_content' do
@@ -118,6 +120,15 @@ RSpec.describe Hyrax::AVFileSetPresenter do
           let(:read_permission) { false }
 
           it { is_expected.to be_nil }
+        end
+
+        context "when the parent presenter's iiif_version is 3" do
+          let(:parent_presenter) { instance_double("Hyrax::GenericWorkPresenter", iiif_version: 3) }
+
+          it 'creates a V3 content object' do
+            expect(subject).to be_instance_of IIIFManifest::V3::DisplayContent
+            expect(subject.url).to eq "http://test.host/images/#{id}/full/600,/0/default.jpg"
+          end
         end
       end
     end


### PR DESCRIPTION
…tation 3 manifests.

Move accept header parsing into work presenter and use that within the
file set presenter.

Fixes avalonmediasystem/avalon#2957.

Also include bootsnap in test environment and add more directories to gitignore.

@samvera-labs/avalon
