### PR TITLE
Bugfix/choice in manifests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -659,7 +659,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    retriable (3.1.1)
+    retriable (3.1.2)
     riiif (1.7.0)
       deprecation (>= 1.0.0)
       railties (>= 4.2, < 6)
@@ -745,7 +745,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     slop (4.6.2)
-    solr_wrapper (1.2.0)
+    solr_wrapper (2.0.0)
       faraday
       retriable
       ruby-progressbar

--- a/app/presenters/hyrax/displays_content.rb
+++ b/app/presenters/hyrax/displays_content.rb
@@ -74,9 +74,12 @@ module Hyrax
 
       def video_content
         # @see https://github.com/samvera-labs/iiif_manifest
-        return [video_display_content(download_path('mp4'), 'mp4'), video_display_content(download_path('webm'), 'webm')] unless solr_document['files_metadata_ssi'].present?
-        files_metadata = JSON.parse(solr_document['files_metadata_ssi'])
-        files_metadata.map { |f| video_display_content(f['external_file_uri'], f['label']) }
+        if solr_document['files_metadata_ssi'].present?
+          files_metadata = JSON.parse(solr_document['files_metadata_ssi'])
+          external_files = files_metadata.select { |f| f['external_file_uri'].present? }
+          return external_files.map { |f| video_display_content(f['external_file_uri'], f['label']) } unless external_files.empty?
+        end
+        [video_display_content(download_path('mp4'), 'mp4'), video_display_content(download_path('webm'), 'webm')]
       end
 
       def video_display_content(url, label = '')
@@ -89,9 +92,12 @@ module Hyrax
       end
 
       def audio_content
-        return [audio_display_content(download_path('ogg'), 'ogg'), audio_display_content(download_path('mp3'), 'mp3')] unless solr_document['files_metadata_ssi'].present?
-        files_metadata = JSON.parse(solr_document['files_metadata_ssi'])
-        files_metadata.map { |f| audio_display_content(f['external_file_uri'], f['label']) }
+        if solr_document['files_metadata_ssi'].present?
+          files_metadata = JSON.parse(solr_document['files_metadata_ssi'])
+          external_files = files_metadata.select { |f| f['external_file_uri'].present? }
+          return external_files.map { |f| audio_display_content(f['external_file_uri'], f['label']) } unless external_files.empty?
+        end
+        [audio_display_content(download_path('ogg'), 'ogg'), audio_display_content(download_path('mp3'), 'mp3')]
       end
 
       def audio_display_content(url, label = '')


### PR DESCRIPTION
Fixes #181.

Assumptions were being made when external file support was added.  These broke the manifests for works that didn't have external files.  This PR fixes those problems but still retains some assumptions that will need to be dealt with later.

Future Work:
- Remove assumptions that any external file is a streaming derivative
- Write tests for external files in the presenter

@samvera-labs/avalon
