### PR TITLE
Bump version of rack due to security issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -558,7 +558,7 @@ GEM
       nokogiri (~> 1.6)
       rails (~> 5.0)
       rdf
-    rack (2.0.5)
+    rack (2.0.6)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)


### PR DESCRIPTION
https://seclists.org/oss-sec/2018/q4/128
https://seclists.org/oss-sec/2018/q4/129

@samvera-labs/avalon
