### PR TITLE
Remove old yarn workaround

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,10 +65,9 @@ services:
       - REDIS_HOST=redis
       - FEDORA_URL=http://fedora:8080/fedora/rest
       - SOLR_URL=http://solr:8983/solr/avalon
-      - WEBPACKER_NODE_MODULES_BIN_PATH=/home/app/node_modules/.bin
     volumes:
       - bundle:/usr/local/bundle
-      - npms:/home/app/node_modules
+      - npms:/home/app/avalon/node_modules
     networks:
       external:
       internal:

--- a/docker/rails_init-dev.sh
+++ b/docker/rails_init-dev.sh
@@ -14,7 +14,6 @@ bundle install $BUNDLE_FLAGS
 
 echo " `date` : Yarn install"
 # Workaround from https://github.com/yarnpkg/yarn/issues/2782
-yarn config set -- --modules-folder "/home/app/node_modules"
 yarn install
 
 echo " `date` : Remove server pid"


### PR DESCRIPTION
with a better workaround: mounting a volume over node_modules folder.